### PR TITLE
Fix Facebook DYI export parser for current format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Run tests
+        run: cargo test --locked

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ friends.json
 foo.txt
 *.ttl
 *.json
+
+# Keep synthetic test fixtures
+!tests/fixtures/*.json

--- a/README.md
+++ b/README.md
@@ -17,48 +17,53 @@ This project aims to encourage SOLID adoption by simplifying the process of expr
 
 Note: If you want to learn more about the theory beTo learn more about this, I suggest reading [Linked Data Fundamentals](https://solid.inrupt.com/docs/intro-to-linked-data) on the SOLID website.
 
-## Step 1: Download You Data from Facebook
+## Step 1: Download Your Data from Facebook
 
-1. Navigate to Facebook's [Download Your Information](https://www.facebook.com/dyi/?x=AdkiqAMlydfH5oKw).
-2. Under Format, select JSON
-3. In "Your Information", you can unselect all and then only check "Profile Information." This is the only data we require
-4. Wait for Facebook to complete the batch export process. This can take an hour or so.
-5. Download the zip file to a suitable location
-6. Extract the zip file and copy `profile_information.json` to handy location
+1. Navigate to [Meta Accounts Center → Your information and permissions → Download your information](https://accountscenter.facebook.com/info_and_permissions/dyi/).
+2. Click **Export your information** → **Create export**.
+3. Under **Specific types of information**, check only **Profile information** (to keep the export small and fast).
+4. Set Format → **JSON**, Date range → **All time**, Media quality → **Low**.
+5. Click **Submit request** and wait for the email notification (usually a few minutes for profile-only exports).
+6. Download the zip file and extract it.
+7. The profile file is at: `<extracted-folder>/personal_information/profile_information/profile_information.json`
 
-## Step 2: [Optional] Export your connections
+## Step 2: [Optional] Export your connections with profile URLs
 
-Facebook's [Download Your Information](https://www.facebook.com/dyi/?x=AdkiqAMlydfH5oKw) advertises the following:
-
-
-> You can download a copy of your Facebook information at any time. You can download a complete copy, or you can select only the types of information and date ranges you want. You can choose to receive your information in an HTML format that is easy to view, or a JSON format, which could allow another service to more easily import it.
-
-
-This is quite useful for exporting profile information and all of the Facebook metadata that Facebook tags you with for advertising and tracking purposes. By downloading your personal data, you can get a good grasp of the data that Facebook has on you, and that can help you make informed decisions about your privacy settings and the degree to which your are comfortable being tracked while using Facebook.
-
-However, the most important and valuable data on a social network is often not your profile information, but your friend connections which define your role in the social graph. Looking through the zip file containing JSON of much of my profile, such data was conspicuously absent.
-
-While Facebook does allow you to export "Friends" data, the data only shows a human-friendly encoding of the friend's name. Realistically, services require some sort of globally unique identifier (GUID) to be able to identify someone on the web,which for Facebook would likely be the public URL of a user's Facebook profile. 
+Facebook's "Download Your Information" export includes a `friends_v2` list, but it only contains friend names — no profile URLs. Realistically, services require a globally unique identifier to identify someone on the web, which for Facebook is the public URL of their profile.
 
 `"John Smith" is not useful, but https://www.facebook.com/johnjohn.smith.12345 is.`
 
-To get around this, we can scrape this data off our Facebook profiles using browser DevTools and a bit of JavaScript.
+To get the URLs, we scrape your friends page using browser DevTools and a bit of JavaScript.
 
-1. Go to https://www.facebook.com/bushidocodes/friends. The page lazy-loads friends for performance reasons, so scroll to the bottom of the friends section until all friends are listed. You should see a page break showing "More About You" when you are at the bottom of the friends section
-2. Open your browser DevTools to the console (Ctrl+Shift+j on Chromium on Windows)
-3. Review the following JavaScript code to trust that I'm not doing anything nefarious. The script essentially extracts your list of friends and the URL of their Facebook profiles. 
+1. Go to `https://www.facebook.com/<your-username>/friends`. The page lazy-loads friends, so **scroll to the very bottom** of the friends list until all friends are loaded.
+2. Open browser DevTools to the Console tab (Ctrl+Shift+J on Chromium/Windows, Cmd+Option+J on Mac).
+3. Review the following JavaScript — it finds all profile links on the page, excludes your own, and deduplicates:
 ```js
-JSON.stringify([...document.querySelectorAll("[data-testid = 'friend_list_item']")].map(el => [...el.querySelectorAll("*")].filter(child => child.className === "fsl fwb fcb")[0].firstChild).map(el => ({name: el.textContent, target: `${el.getAttribute("href")}`.split("?")[0]})))
+JSON.stringify((function(){const my=location.href.replace('/friends','').split('?')[0];const seen=new Set();return[...document.querySelectorAll('a')].filter(a=>{const h=a.href||'';return(h.match(/facebook\.com\/[a-zA-Z0-9._]+$/)||h.match(/facebook\.com\/profile\.php\?id=\d+/))&&a.innerText.trim().length>1&&!h.includes(my);}).map(a=>({name:a.innerText.trim(),target:a.href.match(/profile\.php/)?a.href:a.href.split('?')[0]})).filter(f=>!seen.has(f.target)&&seen.add(f.target));}()))
 ```
-4. After executing, you should see the first bit of the resulting JSON object. At the bottom (in Chromium), you have a Copy button. Click to copy this data.
-![Image showing the copy button in devtools](./docs/copy-json.jpg)
-5. Use a code editor to paste this data into a `friends.json` file and save to the same directory as `profile_information.json`
+4. After executing, you'll see the JSON result. In Chromium, right-click the output → **Copy string contents** (or click the Copy button at the bottom of the console output).
+5. Paste the copied data into a `friends.json` file.
 
 ## Step 3: Download and Run Binary
 
-1. [Download the binary for the appropriate platform and architecture](https://github.com/bushidocodes/hatchling/releases) (at this time, only x64 Linux and Windows are supported) to the same directory as your JSON files
-2. Start a command prompt and navigate to the folder with the binary and JSON files
-3. Run `hatchling.exe profile_information.json out.ttl` if you skipped Step 2. Otherwise run `hatchling.exe --friends friends.json profile_information.json out.ttl`.
+1. [Download the binary for the appropriate platform and architecture](https://github.com/bushidocodes/hatchling/releases) (at this time, only x64 Linux and Windows are supported).
+2. Start a command prompt and run one of:
+
+**Profile only** (no friends):
+```
+hatchling.exe path/to/profile_information.json out.ttl
+```
+
+**With friends from the DYI export** (names only, no profile URLs):
+```
+hatchling.exe path/to/profile_information.json out.ttl --friends path/to/your_friends.json
+```
+The DYI friends file is at: `<extracted-folder>/connections/friends/your_friends.json`
+
+**With friends scraped via Step 2** (includes profile URLs):
+```
+hatchling.exe path/to/profile_information.json out.ttl --friends friends.json
+```
 
 ## Step 4: Validate and Edit Output file
 

--- a/src/facebook_parser.rs
+++ b/src/facebook_parser.rs
@@ -348,9 +348,23 @@ fn fix_facebook_encoding(input: &str) -> String {
                 result.push_str(&input[seq_start..i]);
             }
         } else {
-            // Facebook's JSON export is ASCII; all non-ASCII is \uXXXX-escaped.
-            result.push(s[i] as char);
-            i += 1;
+            // Facebook's DYI JSON export is ASCII (all non-ASCII is \uXXXX-escaped),
+            // but browser-scraped JSON from JSON.stringify contains literal UTF-8 bytes.
+            // Handle both: pass ASCII bytes through directly; decode multi-byte sequences.
+            if s[i] < 0x80 {
+                result.push(s[i] as char);
+                i += 1;
+            } else {
+                let seq_len = if s[i] >= 0xF0 { 4 } else if s[i] >= 0xE0 { 3 } else { 2 };
+                let end = (i + seq_len).min(len);
+                if let Ok(s_str) = std::str::from_utf8(&s[i..end]) {
+                    result.push_str(s_str);
+                    i = end;
+                } else {
+                    result.push(s[i] as char);
+                    i += 1;
+                }
+            }
         }
     }
 

--- a/src/facebook_parser.rs
+++ b/src/facebook_parser.rs
@@ -1,22 +1,65 @@
 use serde::Deserialize;
+use serde_json::Value;
 use std::io;
 
-#[derive(Deserialize)]
-pub struct FBFriends {
-    pub friends: Vec<FBFriend>,
-}
+// --- Friends ---
 
 #[derive(Deserialize)]
 pub struct FBFriend {
     #[serde(default)]
     pub name: String,
+    /// Only present in the legacy browser-scraping format.
     #[serde(default)]
     pub target: String,
+    /// Present in the official "Download Your Information" export (friends_v2).
+    #[serde(default)]
+    pub timestamp: u64,
 }
+
+#[derive(Deserialize)]
+struct FriendsV2Wrapper {
+    friends_v2: Vec<FBFriend>,
+}
+
+#[derive(Deserialize)]
+struct FriendsWrapper {
+    friends: Vec<FBFriend>,
+}
+
+pub struct FBFriends;
 
 impl FBFriends {
     pub fn new(contents: &str) -> Result<Vec<FBFriend>, io::Error> {
-        let p: Vec<FBFriend> = serde_json::from_str(&contents)?;
+        let fixed = fix_facebook_encoding(contents);
+        // Try current official DYI format: {"friends_v2": [...]}
+        if let Ok(w) = serde_json::from_str::<FriendsV2Wrapper>(&fixed) {
+            return Ok(w.friends_v2);
+        }
+        // Try older official DYI format: {"friends": [...]}
+        if let Ok(w) = serde_json::from_str::<FriendsWrapper>(&fixed) {
+            return Ok(w.friends);
+        }
+        // Fall back to the legacy browser-scraping format: [{name, target}, ...]
+        let p: Vec<FBFriend> = serde_json::from_str(&fixed)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(p)
+    }
+}
+
+// --- Profile ---
+
+#[derive(Deserialize, Debug)]
+pub struct FBProfileInformation {
+    /// Accepts both the old "profile" key and the current "profile_v2" key.
+    #[serde(alias = "profile_v2")]
+    pub profile: Profile,
+}
+
+impl FBProfileInformation {
+    pub fn new(contents: &str) -> Result<FBProfileInformation, io::Error> {
+        let fixed = fix_facebook_encoding(contents);
+        let p: FBProfileInformation = serde_json::from_str(&fixed)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         Ok(p)
     }
 }
@@ -25,43 +68,52 @@ impl FBFriends {
 pub struct Profile {
     pub name: Name,
     pub emails: Emails,
+    #[serde(default)]
     pub birthday: Date,
+    #[serde(default)]
     pub gender: Gender,
-    pub previous_names: Vec<TimestampedString>,
+    #[serde(default)]
+    pub previous_names: Vec<Value>,
+    #[serde(default)]
     pub current_city: TimestampedString,
+    #[serde(default)]
     pub hometown: TimestampedString,
+    #[serde(default)]
     pub relationship: Relationship,
+    #[serde(default)]
     pub family_members: Vec<FamilyMember>,
+    #[serde(default)]
     pub education_experiences: Vec<EducationExperience>,
-    pub work_experiences: Vec<WorkExperience>,
-    pub languages: Vec<String>,
+    /// Stored as raw JSON because the field structure changed between export versions.
+    #[serde(default)]
+    pub work_experiences: Vec<Value>,
+    /// Stored as raw JSON because the field structure changed between export versions
+    /// (was Vec<String>, now Vec<{name, timestamp}>).
+    #[serde(default)]
+    pub languages: Vec<Value>,
+    #[serde(default)]
     pub political_view: View,
+    #[serde(default)]
     pub religious_view: View,
     #[serde(default)]
     pub professional_skills: Vec<String>,
+    #[serde(default)]
     pub address: Address,
+    #[serde(default)]
     pub phone_numbers: Vec<PhoneNumber>,
     #[serde(default)]
     pub username: String,
-    pub places_lived: Vec<PlaceLived>,
+    /// Stored as raw JSON because the nested structure changed between export versions.
+    #[serde(default)]
+    pub places_lived: Vec<Value>,
     #[serde(default)]
     pub name_pronunciation: String,
     #[serde(default)]
-    pub profile_uri: String, // Is there a URL type?
+    pub profile_uri: String,
+    /// Stored as raw JSON because the field changed from a plain string to
+    /// an object {name, timestamp} in newer exports.
     #[serde(default)]
-    pub intro_bio: String,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct FBProfileInformation {
-    pub profile: Profile,
-}
-
-impl FBProfileInformation {
-    pub fn new(contents: &str) -> Result<FBProfileInformation, io::Error> {
-        let p: FBProfileInformation = serde_json::from_str(&contents)?;
-        Ok(p)
-    }
+    pub intro_bio: Value,
 }
 
 #[derive(Deserialize, Debug)]
@@ -75,6 +127,7 @@ pub struct Name {
     #[serde(default)]
     pub last_name: String,
 }
+
 #[derive(Deserialize, Debug)]
 pub struct Emails {
     #[serde(default)]
@@ -86,7 +139,8 @@ pub struct Emails {
     #[serde(default)]
     pub ad_account_emails: Vec<String>,
 }
-#[derive(Deserialize, Debug)]
+
+#[derive(Deserialize, Debug, Default)]
 pub struct Date {
     #[serde(default)]
     pub year: u16,
@@ -95,34 +149,43 @@ pub struct Date {
     #[serde(default)]
     pub day: u8,
 }
-#[derive(Deserialize, Debug)]
+
+#[derive(Deserialize, Debug, Default)]
 pub struct Gender {
     #[serde(default)]
     pub gender_option: String,
     #[serde(default)]
     pub pronoun: String,
 }
-#[derive(Deserialize, Debug)]
+
+#[derive(Deserialize, Debug, Default)]
 pub struct TimestampedString {
     #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub timestamp: u64,
 }
-#[derive(Deserialize, Debug)]
+
+#[derive(Deserialize, Debug, Default)]
 pub struct Relationship {
     #[serde(default)]
     pub status: String,
     #[serde(default)]
     pub partner: String,
+    #[serde(default)]
     pub anniversary: Date,
+    #[serde(default)]
+    pub timestamp: u64,
 }
+
 #[derive(Deserialize, Debug)]
 pub struct FamilyMember {
     #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub relation: String,
+    #[serde(default)]
+    pub timestamp: u64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -153,7 +216,7 @@ pub enum EducationExperience {
         #[serde(default)]
         description: String,
         #[serde(default)]
-        concentrations: Vec<String>, // Up to three?
+        concentrations: Vec<String>,
     },
     #[serde(rename = "Graduate School")]
     GraduateSchool {
@@ -163,6 +226,7 @@ pub enum EducationExperience {
         start_timestamp: u64,
         #[serde(default)]
         end_timestamp: u64,
+        #[serde(default)]
         graduated: bool,
         #[serde(default)]
         description: String,
@@ -171,34 +235,20 @@ pub enum EducationExperience {
         #[serde(default)]
         degree: String,
     },
+    /// Catch-all for any school_type values not listed above.
+    #[serde(other)]
+    Other,
 }
 
-// TODO: Determine how "I currently work here" is encoded
-#[derive(Deserialize, Debug)]
-pub struct WorkExperience {
-    #[serde(default)]
-    pub employer: String,
-    #[serde(default)]
-    pub title: String,
-    #[serde(default)]
-    pub location: String,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub start_timestamp: u64,
-    #[serde(default)]
-    pub end_timestamp: u64,
-}
-
-// Used for political and religious views
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 pub struct View {
     #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub description: String,
 }
-#[derive(Deserialize, Debug)]
+
+#[derive(Deserialize, Debug, Default)]
 pub struct Address {
     #[serde(default)]
     pub street: String,
@@ -215,6 +265,7 @@ pub struct Address {
     #[serde(default)]
     pub region: String,
 }
+
 #[derive(Deserialize, Debug)]
 pub struct PhoneNumber {
     #[serde(default)]
@@ -224,10 +275,98 @@ pub struct PhoneNumber {
     #[serde(default)]
     pub verified: bool,
 }
-#[derive(Deserialize, Debug)]
-pub struct PlaceLived {
-    #[serde(default)]
-    pub place: String,
-    #[serde(default)]
-    pub start_timestamp: u64, // No clear end_timestamp
+
+// --- Encoding fix ---
+
+/// Facebook's JSON encoder has a bug: UTF-8 multi-byte characters are output as
+/// consecutive \u00XX escape sequences (one per byte) instead of a single \uXXXX
+/// sequence. For example, 'é' (U+00E9, UTF-8: 0xC3 0xA9) appears as Ã©
+/// instead of é. This function detects and corrects those sequences in the
+/// raw JSON string before it is handed to serde_json.
+fn fix_facebook_encoding(input: &str) -> String {
+    let s = input.as_bytes();
+    let len = s.len();
+    let mut result = String::with_capacity(len);
+    let mut i = 0;
+
+    while i < len {
+        // Detect the start of a \u00XX pattern (6 bytes: \, u, 0, 0, H, H).
+        if i + 5 < len
+            && s[i] == b'\\'
+            && s[i + 1] == b'u'
+            && s[i + 2] == b'0'
+            && s[i + 3] == b'0'
+            && is_hex(s[i + 4])
+            && is_hex(s[i + 5])
+        {
+            let seq_start = i;
+            let mut buf: Vec<u8> = Vec::new();
+
+            // Collect all consecutive \u00XX sequences.
+            while i + 5 < len
+                && s[i] == b'\\'
+                && s[i + 1] == b'u'
+                && s[i + 2] == b'0'
+                && s[i + 3] == b'0'
+                && is_hex(s[i + 4])
+                && is_hex(s[i + 5])
+            {
+                buf.push((hex_digit(s[i + 4]) << 4) | hex_digit(s[i + 5]));
+                i += 6;
+            }
+
+            // Only attempt to fix sequences with a high byte (0x80+), which are the
+            // ones that appear as the result of Facebook's broken encoding.
+            if buf.len() > 1 || (buf.len() == 1 && buf[0] >= 0x80) {
+                match std::str::from_utf8(&buf) {
+                    Ok(decoded) => {
+                        for ch in decoded.chars() {
+                            let code = ch as u32;
+                            if code > 0xFFFF {
+                                // Encode as a JSON surrogate pair.
+                                let adj = code - 0x10000;
+                                result.push_str(&format!(
+                                    "\\u{:04x}\\u{:04x}",
+                                    0xD800 + (adj >> 10),
+                                    0xDC00 + (adj & 0x3FF)
+                                ));
+                            } else if code > 0x7F {
+                                result.push_str(&format!("\\u{:04x}", code));
+                            } else {
+                                result.push(ch);
+                            }
+                        }
+                        continue;
+                    }
+                    Err(_) => {
+                        // Not valid UTF-8 — preserve the original escape sequences.
+                        result.push_str(&input[seq_start..i]);
+                    }
+                }
+            } else {
+                // Single-byte value or pure ASCII — preserve as-is.
+                result.push_str(&input[seq_start..i]);
+            }
+        } else {
+            // Facebook's JSON export is ASCII; all non-ASCII is \uXXXX-escaped.
+            result.push(s[i] as char);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+fn is_hex(b: u8) -> bool {
+    matches!(b, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')
+}
+
+fn hex_digit(b: u8) -> u8 {
+    if b <= b'9' {
+        b - b'0'
+    } else if b <= b'F' {
+        b - b'A' + 10
+    } else {
+        b - b'a' + 10
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,9 @@ pub fn convert_facebook_to_solid(
         profile.set_gender(&my_fb_profile.profile.gender.gender_option);
     }
 
-    if !my_fb_profile.profile.birthday.month > 0
-        && !my_fb_profile.profile.birthday.day > 0
-        && !my_fb_profile.profile.birthday.year > 0
+    if my_fb_profile.profile.birthday.month > 0
+        && my_fb_profile.profile.birthday.day > 0
+        && my_fb_profile.profile.birthday.year > 0
     {
         profile.set_birthday_and_age(
             my_fb_profile.profile.birthday.month.into(),
@@ -96,6 +96,7 @@ pub fn convert_facebook_to_solid(
                     profile.add_alumni_relationship(&name)
                 };
             }
+            EducationExperience::Other => {}
         }
     }
 

--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -385,7 +385,9 @@ impl Profile {
             &self.graph.create_literal_node(name.to_string()),
         ));
 
-        self.add_account(fb_profile_url, Some(&clean_string(name)));
+        if !fb_profile_url.is_empty() {
+            self.add_account(fb_profile_url, Some(&clean_string(name)));
+        }
 
         self.graph.add_triple(&Triple::new(
             &self.graph.create_uri_node(&Uri::new("#me".to_string())),

--- a/tests/fixtures/friends_scraped.json
+++ b/tests/fixtures/friends_scraped.json
@@ -1,0 +1,12 @@
+[
+  { "name": "Alice Nguyen",          "target": "https://www.facebook.com/alice.nguyen.503" },
+  { "name": "Bob Kowalski",          "target": "https://www.facebook.com/bob.kowalski.77" },
+  { "name": "Carmen Reyes-Morales",  "target": "https://www.facebook.com/carmen.reyes.morales" },
+  { "name": "David Okonkwo",         "target": "https://www.facebook.com/david.okonkwo" },
+  { "name": "Elena Petrová",         "target": "https://www.facebook.com/elena.petrova.cz" },
+  { "name": "François Beaumont",     "target": "https://www.facebook.com/francois.beaumont" },
+  { "name": "Gabriela Müller",       "target": "https://www.facebook.com/gabi.mueller.de" },
+  { "name": "Hiroshi Tanaka",        "target": "https://www.facebook.com/hiroshi.tanaka.jp" },
+  { "name": "Ingrid Björnsdóttir",   "target": "https://www.facebook.com/ingrid.bjornsdottir" },
+  { "name": "José María Vázquez",    "target": "https://www.facebook.com/profile.php?id=100012345678" }
+]

--- a/tests/fixtures/profile_information.json
+++ b/tests/fixtures/profile_information.json
@@ -1,0 +1,169 @@
+{
+  "profile_v2": {
+    "name": {
+      "full_name": "Jane Doe-Smith",
+      "first_name": "Jane",
+      "middle_name": "Marie",
+      "last_name": "Doe-Smith"
+    },
+    "emails": {
+      "emails": [
+        "jane.doe@example.com",
+        "janedoe1985@gmail.com"
+      ],
+      "previous_emails": [
+        "jdoe1985@yahoo.com"
+      ],
+      "pending_emails": [],
+      "ad_account_emails": []
+    },
+    "birthday": {
+      "year": 1985,
+      "month": 3,
+      "day": 14
+    },
+    "gender": {
+      "gender_option": "Female",
+      "pronoun": "She/Her"
+    },
+    "previous_names": [
+      {
+        "name": "Jane Marie Doe",
+        "timestamp": 1420070400
+      }
+    ],
+    "other_names": [],
+    "current_city": {
+      "name": "Portland, Oregon",
+      "timestamp": 1546300800
+    },
+    "hometown": {
+      "name": "Eugene, Oregon",
+      "timestamp": 0
+    },
+    "relationship": {
+      "status": "Married",
+      "partner": "Alex Smith",
+      "anniversary": {
+        "year": 2012,
+        "month": 7,
+        "day": 4
+      },
+      "timestamp": 1341360000
+    },
+    "family_members": [
+      {
+        "name": "Margaret Doe",
+        "relation": "Mother",
+        "timestamp": 1403761125
+      },
+      {
+        "name": "Robert Doe",
+        "relation": "Father",
+        "timestamp": 1403761125
+      },
+      {
+        "name": "Alex Smith",
+        "relation": "Spouse",
+        "timestamp": 1341360000
+      },
+      {
+        "name": "Carlos López-García",
+        "relation": "Brother",
+        "timestamp": 1403761125
+      }
+    ],
+    "education_experiences": [
+      {
+        "school_type": "High School",
+        "name": "Eugene High School",
+        "start_timestamp": 946684800,
+        "end_timestamp": 1088640000,
+        "graduated": true,
+        "description": ""
+      },
+      {
+        "school_type": "College",
+        "name": "University of Oregon",
+        "start_timestamp": 1096588800,
+        "end_timestamp": 1214870400,
+        "graduated": true,
+        "description": "B.S. Computer Science",
+        "concentrations": ["Computer Science", "Mathematics"]
+      },
+      {
+        "school_type": "Graduate School",
+        "name": "Oregon State University",
+        "start_timestamp": 1220227200,
+        "end_timestamp": 1341100800,
+        "graduated": true,
+        "description": "M.S. Software Engineering",
+        "concentrations": ["Software Engineering"],
+        "degree": "Master of Science"
+      }
+    ],
+    "work_experiences": [
+      {
+        "employer": {
+          "name": "Acme Software Inc."
+        },
+        "title": "Senior Software Engineer",
+        "location": "Portland, OR",
+        "description": "Backend systems and APIs",
+        "start_timestamp": 1341100800,
+        "end_timestamp": 0
+      }
+    ],
+    "languages": [
+      {
+        "name": "English language",
+        "timestamp": 0
+      },
+      {
+        "name": "Spanish",
+        "timestamp": 0
+      }
+    ],
+    "websites": [
+      {
+        "address": "https://janedoesmith.example.com/"
+      }
+    ],
+    "screen_names": [
+      {
+        "service_name": "GitHub",
+        "names": [
+          {
+            "name": "janedoe-dev",
+            "timestamp": 0
+          }
+        ]
+      },
+      {
+        "service_name": "LinkedIn",
+        "names": [
+          {
+            "name": "janedoesmith",
+            "timestamp": 0
+          }
+        ]
+      }
+    ],
+    "phone_numbers": [
+      {
+        "phone_type": "Mobile",
+        "phone_number": "+15035550123",
+        "verified": true,
+        "creation_time": 0
+      }
+    ],
+    "username": "jane.doe.smith.1985",
+    "registration_timestamp": 1170892800,
+    "profile_uri": "https://www.facebook.com/jane.doe.smith.1985",
+    "intro_bio": {
+      "name": "Software engineer, coffee enthusiast, and amateur astronomer. Oregon born and raised.",
+      "timestamp": 1497881882
+    },
+    "profile_category": "Personal"
+  }
+}

--- a/tests/fixtures/your_friends.json
+++ b/tests/fixtures/your_friends.json
@@ -1,0 +1,14 @@
+{
+  "friends_v2": [
+    { "name": "Alice Nguyen", "timestamp": 1190678400 },
+    { "name": "Bob Kowalski", "timestamp": 1201824000 },
+    { "name": "Carmen Reyes-Morales", "timestamp": 1214870400 },
+    { "name": "David Okonkwo", "timestamp": 1220486400 },
+    { "name": "Elena Petrová", "timestamp": 1230768000 },
+    { "name": "François Beaumont", "timestamp": 1243468800 },
+    { "name": "Gabriela Müller", "timestamp": 1256428800 },
+    { "name": "Hiroshi Tanaka", "timestamp": 1262304000 },
+    { "name": "Ingrid Björnsdóttir", "timestamp": 1277337600 },
+    { "name": "José María Vázquez", "timestamp": 1293840000 }
+  ]
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,162 @@
+use hatchling::convert_facebook_to_solid;
+
+const PROFILE: &str = include_str!("fixtures/profile_information.json");
+const FRIENDS_DYI: &str = include_str!("fixtures/your_friends.json");
+const FRIENDS_SCRAPED: &str = include_str!("fixtures/friends_scraped.json");
+
+// ---------------------------------------------------------------------------
+// Profile parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn profile_parses_without_error() {
+    assert!(convert_facebook_to_solid(PROFILE, None).is_ok());
+}
+
+#[test]
+fn profile_name_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("Jane Doe-Smith"), "full name missing");
+    assert!(ttl.contains("foaf:firstName \"Jane\""), "first name missing");
+    assert!(ttl.contains("foaf:lastName \"Doe-Smith\""), "last name missing");
+}
+
+#[test]
+fn profile_email_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("mailto:jane.doe@example.com"), "primary email missing");
+    assert!(ttl.contains("mailto:janedoe1985@gmail.com"), "secondary email missing");
+}
+
+#[test]
+fn profile_birthday_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("schema:birthDate \"1985-3-14\""), "birthDate missing");
+    assert!(ttl.contains("foaf:birthday \"3-14\""), "foaf birthday missing");
+}
+
+#[test]
+fn profile_phone_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("tel:+15035550123"), "phone number missing");
+}
+
+#[test]
+fn profile_locations_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("Portland, Oregon"), "homeLocation missing");
+    assert!(ttl.contains("Eugene, Oregon"), "birthPlace missing");
+}
+
+#[test]
+fn profile_facebook_account_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("jane.doe.smith.1985"), "Facebook username missing");
+}
+
+#[test]
+fn profile_gender_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("foaf:gender \"Female\""), "foaf gender missing");
+    assert!(ttl.contains("schema:gender \"Female\""), "schema gender missing");
+}
+
+// ---------------------------------------------------------------------------
+// Education
+// ---------------------------------------------------------------------------
+
+#[test]
+fn graduated_schools_produce_alumni_triples() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("University of Oregon"), "college missing");
+    assert!(ttl.contains("Oregon State University"), "grad school missing");
+    assert!(ttl.contains("Eugene High School"), "high school missing");
+}
+
+// ---------------------------------------------------------------------------
+// Friends — DYI format (friends_v2, names + timestamps, no URLs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dyi_friends_parse_without_error() {
+    assert!(convert_facebook_to_solid(PROFILE, Some(FRIENDS_DYI)).is_ok());
+}
+
+#[test]
+fn dyi_friends_appear_in_foaf_knows() {
+    let ttl = convert_facebook_to_solid(PROFILE, Some(FRIENDS_DYI)).unwrap();
+    assert!(ttl.contains("foaf:knows"), "foaf:knows missing");
+    assert!(ttl.contains("Alice Nguyen"), "friend missing");
+    assert!(ttl.contains("Bob Kowalski"), "friend missing");
+}
+
+#[test]
+fn dyi_friends_no_foaf_account_triples() {
+    // DYI export has no profile URLs — no foaf:account should be emitted for friends.
+    // Only the owner's own account triple should appear.
+    let ttl = convert_facebook_to_solid(PROFILE, Some(FRIENDS_DYI)).unwrap();
+    let account_count = ttl.matches("foaf:account").count();
+    assert_eq!(account_count, 1, "expected 1 foaf:account (owner only), got {account_count}");
+}
+
+#[test]
+fn dyi_friends_non_ascii_names_decoded() {
+    // DYI export uses Facebook's \u00XX encoding bug — fix_facebook_encoding must handle it.
+    // The fixture uses literal UTF-8 (written by the test author), so this exercises
+    // the pass-through path; the broken-encoding path is tested separately below.
+    let ttl = convert_facebook_to_solid(PROFILE, Some(FRIENDS_DYI)).unwrap();
+    assert!(ttl.contains("Elena Petrová"),       "Petrová corrupted");
+    assert!(ttl.contains("François Beaumont"),   "François corrupted");
+    assert!(ttl.contains("Gabriela Müller"),     "Müller corrupted");
+    assert!(ttl.contains("Ingrid Björnsdóttir"), "Björnsdóttir corrupted");
+    assert!(ttl.contains("José María Vázquez"),  "José María corrupted");
+}
+
+// ---------------------------------------------------------------------------
+// Friends — scraped format ([{name, target}], includes profile URLs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scraped_friends_parse_without_error() {
+    assert!(convert_facebook_to_solid(PROFILE, Some(FRIENDS_SCRAPED)).is_ok());
+}
+
+#[test]
+fn scraped_friends_produce_foaf_account_triples() {
+    let ttl = convert_facebook_to_solid(PROFILE, Some(FRIENDS_SCRAPED)).unwrap();
+    assert!(ttl.contains("https://www.facebook.com/alice.nguyen.503"), "alice URL missing");
+    assert!(ttl.contains("https://www.facebook.com/francois.beaumont"), "francois URL missing");
+    // Numeric profile.php?id= URL must be preserved intact
+    assert!(ttl.contains("profile.php?id=100012345678"), "numeric ID URL missing");
+}
+
+#[test]
+fn scraped_friends_non_ascii_names_not_corrupted() {
+    // Scraped JSON contains literal UTF-8 bytes — fix_facebook_encoding must
+    // pass them through without Latin-1 reinterpretation.
+    let ttl = convert_facebook_to_solid(PROFILE, Some(FRIENDS_SCRAPED)).unwrap();
+    assert!(ttl.contains("François Beaumont"),   "François corrupted to Ã sequence");
+    assert!(ttl.contains("Gabriela Müller"),     "Müller corrupted");
+    assert!(ttl.contains("Elena Petrová"),       "Petrová corrupted");
+    assert!(ttl.contains("Ingrid Björnsdóttir"), "Björnsdóttir corrupted");
+    assert!(ttl.contains("José María Vázquez"),  "José María corrupted");
+}
+
+// ---------------------------------------------------------------------------
+// Facebook UTF-8 encoding bug fix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn facebook_broken_utf8_encoding_is_fixed() {
+    // Facebook's encoder emits multibyte UTF-8 characters as consecutive
+    // \u00XX escapes — one escape per byte instead of a single \uXXXX.
+    // Example: é (U+00E9, UTF-8 bytes: 0xC3 0xA9) → Ã©
+    //          è (U+00E8, UTF-8 bytes: 0xC3 0xA8) → Ã¨
+    // fix_facebook_encoding() must reassemble these into the correct codepoint.
+    // In a Rust raw string r#"..."# the backslash is literal, so Ã is the
+    // six-character sequence that Facebook literally writes into its JSON file.
+    let broken = "{\"profile_v2\":{\"name\":{\"full_name\":\"Caf\\u00c3\\u00a9 \\u00c3\\u00a9l\\u00c3\\u00a8ve\",\"first_name\":\"Caf\\u00c3\\u00a9\",\"middle_name\":\"\",\"last_name\":\"\\u00c3\\u00a9l\\u00c3\\u00a8ve\"},\"emails\":{\"emails\":[\"test@example.com\"],\"previous_emails\":[],\"pending_emails\":[],\"ad_account_emails\":[]},\"birthday\":{\"year\":0,\"month\":0,\"day\":0},\"gender\":{\"gender_option\":\"\",\"pronoun\":\"\"},\"previous_names\":[],\"family_members\":[],\"education_experiences\":[],\"work_experiences\":[],\"languages\":[],\"phone_numbers\":[],\"current_city\":{\"name\":\"\",\"timestamp\":0},\"hometown\":{\"name\":\"\",\"timestamp\":0},\"relationship\":{\"status\":\"\",\"partner\":\"\",\"anniversary\":{\"year\":0,\"month\":0,\"day\":0},\"timestamp\":0},\"username\":\"\",\"profile_uri\":\"\",\"intro_bio\":{\"name\":\"\",\"timestamp\":0}}}";
+    let ttl = convert_facebook_to_solid(broken, None).unwrap();
+    // After the fix, Ã© → é and Ã¨ → è
+    assert!(ttl.contains("Café élève"), "broken UTF-8 not repaired; expected 'Café élève'");
+}


### PR DESCRIPTION
## Summary

- **Fix parse failures**: Facebook renamed `profile` → `profile_v2` and `friends` → `friends_v2` in their export format; adds serde aliases and a three-format fallback for friends
- **Fix encoding corruption**: Facebook's JSON encoder has a UTF-8 bug (multibyte chars emitted as consecutive `\u00XX` byte escapes); pre-processes the raw JSON string to fix this before parsing
- **Fix broken birthday guard**: `!x > 0` used bitwise NOT (always true) — corrected to `x > 0`
- **Absorb schema changes**: `languages`, `intro_bio`, `work_experiences`, `places_lived` changed structure between export versions — now stored as `Value`/`Vec<Value>`; all other previously-required fields are now `#[serde(default)]`
- **Update README**: new Accounts Center URLs, corrected file paths for the current export folder layout, and a new JS friends scraper that works with Facebook's current React UI (replaces the broken `data-testid`/class-name approach)

## Test plan

- [ ] Run against a real 2026 Facebook DYI export — `profile_v2`, `friends_v2`, non-ASCII names all parse correctly
- [ ] Verify `out.ttl` contains name, emails, birthday, phone, location, birthplace, and full `foaf:knows` list
- [ ] Confirm non-ASCII friend names (e.g. `Sólyom-Fekete Mátyás`) appear decoded correctly in the output
- [ ] Confirm friends with no profile URL do not produce a blank `foaf:account` triple
- [ ] Paste the updated JS snippet into browser console on the friends page and verify it returns `[{name, target}]` JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)