### PR TITLE
fix: zero-pad month/day in birthday/birthDate to comply with ISO 8601

### DIFF
--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -188,7 +188,7 @@ impl Profile {
                 .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/birthday".to_string())),
             &self
                 .graph
-                .create_literal_node(format!("{}-{}", &month, &day)),
+                .create_literal_node(format!("--{:02}-{:02}", &month, &day)),
         ));
         // Uses ISO 8601 https://en.wikipedia.org/wiki/ISO_8601
         self.graph.add_triple(&Triple::new(
@@ -198,7 +198,7 @@ impl Profile {
                 .create_uri_node(&Uri::new("http://schema.org/birthDate".to_string())),
             &self
                 .graph
-                .create_literal_node(format!("{}-{}-{}", &year, &month, &day)),
+                .create_literal_node(format!("{:04}-{:02}-{:02}", &year, &month, &day)),
         ));
 
         // Calculate age. This seems to be kinda broken.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -31,8 +31,8 @@ fn profile_email_in_output() {
 #[test]
 fn profile_birthday_in_output() {
     let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
-    assert!(ttl.contains("schema:birthDate \"1985-3-14\""), "birthDate missing");
-    assert!(ttl.contains("foaf:birthday \"3-14\""), "foaf birthday missing");
+    assert!(ttl.contains("schema:birthDate \"1985-03-14\""), "birthDate missing");
+    assert!(ttl.contains("foaf:birthday \"--03-14\""), "foaf birthday missing");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `foaf:birthday` now emits `--MM-DD` (e.g. `--03-14`) instead of `M-D`
- `schema:birthDate` now emits `YYYY-MM-DD` (e.g. `1985-03-14`) instead of `YYYY-M-D`
- Updated the integration test assertions to match the corrected format

## Test plan

- [ ] `cargo test profile_birthday_in_output` passes
- [ ] `cargo test` (all 17 integration tests) passes

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)