### PR TITLE
feat: emit work experience and profile page triples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,25 @@ pub fn convert_facebook_to_solid(
         );
     }
 
+    if !my_fb_profile.profile.profile_uri.is_empty() {
+        profile.add_profile_page(&my_fb_profile.profile.profile_uri);
+    }
+
+    for work in &my_fb_profile.profile.work_experiences {
+        let employer = work
+            .get("employer")
+            .and_then(|e| e.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or("");
+        let title = work
+            .get("title")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        if !employer.is_empty() {
+            profile.add_work_experience(employer, title);
+        }
+    }
+
     for email in my_fb_profile.profile.emails.emails {
         profile.add_email(&email);
     }

--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -341,6 +341,52 @@ impl Profile {
         ));
     }
 
+    pub fn add_work_experience(&mut self, employer: &str, title: &str) {
+        let org = &self
+            .graph
+            .create_blank_node_with_id(clean_string(employer));
+        self.graph.add_triple(&Triple::new(
+            &org,
+            &self.graph.create_uri_node(&Uri::new("a".to_string())),
+            &self
+                .graph
+                .create_uri_node(&Uri::new("http://schema.org/Organization".to_string())),
+        ));
+        self.graph.add_triple(&Triple::new(
+            &org,
+            &self
+                .graph
+                .create_uri_node(&Uri::new("http://schema.org/name".to_string())),
+            &self.graph.create_literal_node(employer.to_string()),
+        ));
+        self.graph.add_triple(&Triple::new(
+            &self.graph.create_uri_node(&Uri::new("#me".to_string())),
+            &self
+                .graph
+                .create_uri_node(&Uri::new("http://schema.org/worksFor".to_string())),
+            &org,
+        ));
+        if !title.is_empty() {
+            self.graph.add_triple(&Triple::new(
+                &self.graph.create_uri_node(&Uri::new("#me".to_string())),
+                &self
+                    .graph
+                    .create_uri_node(&Uri::new("http://schema.org/jobTitle".to_string())),
+                &self.graph.create_literal_node(title.to_string()),
+            ));
+        }
+    }
+
+    pub fn add_profile_page(&mut self, url: &str) {
+        self.graph.add_triple(&Triple::new(
+            &self.graph.create_uri_node(&Uri::new("#me".to_string())),
+            &self
+                .graph
+                .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/page".to_string())),
+            &self.graph.create_uri_node(&Uri::new(url.to_string())),
+        ));
+    }
+
     // username is a string containing the facebook username
     // target is an option containing a
     pub fn add_account(&mut self, username: &str, account_holder_id_override: Option<&str>) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -62,6 +62,33 @@ fn profile_gender_in_output() {
 }
 
 // ---------------------------------------------------------------------------
+// Profile page
+// ---------------------------------------------------------------------------
+
+#[test]
+fn profile_page_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("foaf:page"), "foaf:page missing");
+    assert!(
+        ttl.contains("https://www.facebook.com/jane.doe.smith.1985"),
+        "profile URI missing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Work experience
+// ---------------------------------------------------------------------------
+
+#[test]
+fn work_experience_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(ttl.contains("Acme Software Inc."), "employer missing");
+    assert!(ttl.contains("Senior Software Engineer"), "job title missing");
+    assert!(ttl.contains("schema:worksFor"), "worksFor predicate missing");
+    assert!(ttl.contains("schema:jobTitle"), "jobTitle predicate missing");
+}
+
+// ---------------------------------------------------------------------------
 // Education
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -79,6 +79,13 @@ fn profile_page_in_output() {
 // Work experience
 // ---------------------------------------------------------------------------
 
+/// Builds a minimal valid profile JSON with the given work_experiences value
+/// substituted in, so synthetic work-experience tests don't need the full fixture.
+fn profile_with_work(work_experiences_json: &str) -> String {
+    const TEMPLATE: &str = r#"{"profile_v2":{"name":{"full_name":"Test User","first_name":"Test","middle_name":"","last_name":"User"},"emails":{"emails":[],"previous_emails":[],"pending_emails":[],"ad_account_emails":[]},"work_experiences":WORK}}"#;
+    TEMPLATE.replace("WORK", work_experiences_json)
+}
+
 #[test]
 fn work_experience_in_output() {
     let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
@@ -86,6 +93,70 @@ fn work_experience_in_output() {
     assert!(ttl.contains("Senior Software Engineer"), "job title missing");
     assert!(ttl.contains("schema:worksFor"), "worksFor predicate missing");
     assert!(ttl.contains("schema:jobTitle"), "jobTitle predicate missing");
+}
+
+#[test]
+fn work_experience_employer_and_title_produce_triples() {
+    let json = profile_with_work(
+        r#"[{"employer":{"name":"Globex Corporation"},"title":"Safety Inspector","start_timestamp":0,"end_timestamp":0}]"#,
+    );
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(ttl.contains("Globex Corporation"));
+    assert!(ttl.contains("Safety Inspector"));
+    assert!(ttl.contains("schema:worksFor"));
+    assert!(ttl.contains("schema:jobTitle"));
+}
+
+#[test]
+fn work_experience_without_title_omits_job_title_triple() {
+    let json = profile_with_work(
+        r#"[{"employer":{"name":"Globex Corporation"},"start_timestamp":0,"end_timestamp":0}]"#,
+    );
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(ttl.contains("Globex Corporation"));
+    assert!(ttl.contains("schema:worksFor"));
+    assert!(!ttl.contains("schema:jobTitle"));
+}
+
+#[test]
+fn work_experience_absent_omits_work_triples() {
+    let json = profile_with_work("[]");
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(!ttl.contains("schema:worksFor"));
+    assert!(!ttl.contains("schema:jobTitle"));
+}
+
+#[test]
+fn work_experience_empty_employer_name_omits_all_work_triples() {
+    let json = profile_with_work(
+        r#"[{"employer":{"name":""},"title":"Engineer","start_timestamp":0,"end_timestamp":0}]"#,
+    );
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(!ttl.contains("schema:worksFor"));
+    assert!(!ttl.contains("schema:jobTitle"));
+}
+
+#[test]
+fn work_experience_missing_employer_key_omits_all_work_triples() {
+    let json = profile_with_work(
+        r#"[{"title":"Engineer","start_timestamp":0,"end_timestamp":0}]"#,
+    );
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(!ttl.contains("schema:worksFor"));
+    assert!(!ttl.contains("schema:jobTitle"));
+}
+
+#[test]
+fn work_experience_multiple_employers_produce_multiple_triples() {
+    let json = profile_with_work(
+        r#"[{"employer":{"name":"Acme Corp"},"title":"Coyote Wrangler"},{"employer":{"name":"Initech"},"title":"TPS Report Author"}]"#,
+    );
+    let ttl = convert_facebook_to_solid(&json, None).unwrap();
+    assert!(ttl.contains("Acme Corp"));
+    assert!(ttl.contains("Coyote Wrangler"));
+    assert!(ttl.contains("Initech"));
+    assert!(ttl.contains("TPS Report Author"));
+    assert!(ttl.contains("schema:worksFor"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#4 Work Experience**: `work_experiences` from the Facebook DYI export now produces `schema:worksFor` (blank-node `schema:Organization` with `schema:name`) and `schema:jobTitle` triples on `#me`, following the same blank-node pattern used for `schema:alumniOf`
- **#1 Profile page (partial)**: `profile_uri` is now emitted as `foaf:page`. The actual profile picture is not available in `profile_information.json`, so `foaf:img` cannot be populated from this source alone

Also closed as stale/out-of-scope via comment:
- **#2 Education**: already implemented (`schema:alumniOf` for all three school types)
- **#3 Scrape friend images**: out of scope — tool processes offline exports, not a browser scraper

## Test plan

- [x] `work_experience_in_output` — verifies employer name, job title, `schema:worksFor`, `schema:jobTitle`
- [x] `profile_page_in_output` — verifies `foaf:page` and the profile URI
- [x] All 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)