### PR TITLE
fix: emit foaf:account object as URI node, not literal string

### DIFF
--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -528,7 +528,7 @@ impl Profile {
             &self
                 .graph
                 .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/account".to_string())),
-            &self.graph.create_literal_node(username.to_string()),
+            &self.graph.create_uri_node(&Uri::new(username.to_string())),
         ));
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -51,7 +51,15 @@ fn profile_locations_in_output() {
 #[test]
 fn profile_facebook_account_in_output() {
     let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
-    assert!(ttl.contains("jane.doe.smith.1985"), "Facebook username missing");
+    // Account URL must be a URI node (<...>), not a literal ("...")
+    assert!(
+        ttl.contains("<https://www.facebook.com/jane.doe.smith.1985>"),
+        "Facebook account must be a URI node"
+    );
+    assert!(
+        !ttl.contains("\"https://www.facebook.com/jane.doe.smith.1985\""),
+        "Facebook account must not be a literal"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #14

## Summary

- `add_account` was calling `create_literal_node(username)`, producing `foaf:account "https://..."` — a plain string literal is not a valid `foaf:OnlineAccount`
- Changed to `create_uri_node(&Uri::new(username))`, producing `foaf:account <https://...>` — the correct URI-node form
- Tightened `profile_facebook_account_in_output` test to assert the angle-bracket form and explicitly reject the quoted form

## Test plan

- [x] `cargo test` — 25/25 integration tests pass, zero warnings
- [x] `profile_facebook_account_in_output` now asserts `<https://www.facebook.com/jane.doe.smith.1985>` (URI) and `!contains("\"https://...")` (not literal)
- [x] `scraped_friends_produce_foaf_account_triples` still passes (substring match still holds inside `<...>`)
- [x] `dyi_friends_no_foaf_account_triples` count check (1) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)