### PR TITLE
fix: remove non-standard foaf:firstName and foaf:lastName predicates

### DIFF
--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -256,13 +256,6 @@ impl Profile {
     pub fn set_last_name(&mut self, lastname: &str) {
         self.graph.add_triple(&Triple::new(
             &self.graph.create_uri_node(&Uri::new("#me".to_string())),
-            &self
-                .graph
-                .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/lastName".to_string())),
-            &self.graph.create_literal_node(lastname.to_string()),
-        ));
-        self.graph.add_triple(&Triple::new(
-            &self.graph.create_uri_node(&Uri::new("#me".to_string())),
             &self.graph.create_uri_node(&Uri::new(
                 "http://xmlns.com/foaf/0.1/familyName".to_string(),
             )),
@@ -278,13 +271,6 @@ impl Profile {
     }
 
     pub fn set_first_name(&mut self, firstname: &str) {
-        self.graph.add_triple(&Triple::new(
-            &self.graph.create_uri_node(&Uri::new("#me".to_string())),
-            &self
-                .graph
-                .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/firstName".to_string())),
-            &self.graph.create_literal_node(firstname.to_string()),
-        ));
         self.graph.add_triple(&Triple::new(
             &self.graph.create_uri_node(&Uri::new("#me".to_string())),
             &self

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,8 +17,8 @@ fn profile_parses_without_error() {
 fn profile_name_in_output() {
     let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
     assert!(ttl.contains("Jane Doe-Smith"), "full name missing");
-    assert!(ttl.contains("foaf:firstName \"Jane\""), "first name missing");
-    assert!(ttl.contains("foaf:lastName \"Doe-Smith\""), "last name missing");
+    assert!(ttl.contains("foaf:givenName \"Jane\""), "first name missing");
+    assert!(ttl.contains("foaf:familyName \"Doe-Smith\""), "last name missing");
 }
 
 #[test]


### PR DESCRIPTION
Closes #15

## Summary

`foaf:firstName` and `foaf:lastName` do not exist in the FOAF specification. The code was already emitting the correct `foaf:givenName` and `foaf:familyName` triples immediately after them, making the non-standard ones redundant and incorrect.

**Removed** from `set_last_name`:
```rust
// removed — foaf:lastName is not a FOAF property
&Uri::new("http://xmlns.com/foaf/0.1/lastName".to_string())
```

**Removed** from `set_first_name`:
```rust
// removed — foaf:firstName is not a FOAF property
&Uri::new("http://xmlns.com/foaf/0.1/firstName".to_string())
```

Integration test assertions updated from `foaf:firstName`/`foaf:lastName` to the standard `foaf:givenName`/`foaf:familyName`.

## Test plan

- [x] `cargo test` — 25/25 tests pass, zero warnings
- [x] `profile_name_in_output` now checks `foaf:givenName "Jane"` and `foaf:familyName "Doe-Smith"` (standard predicates)
- [x] Confirmed `foaf:firstName` and `foaf:lastName` are absent from generated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)