### PR TITLE
fix: remove unused vcard and resource namespace declarations

### DIFF
--- a/src/profile_builder.rs
+++ b/src/profile_builder.rs
@@ -181,15 +181,6 @@ impl Profile {
             "foaf".to_string(),
             Uri::new("http://xmlns.com/foaf/0.1/".to_string()),
         ));
-        new_profile.graph.add_namespace(&Namespace::new(
-            "vcard".to_string(),
-            Uri::new("http://www.w3.org/2006/vcard/ns".to_string()),
-        ));
-        new_profile.graph.add_namespace(&Namespace::new(
-            "resource".to_string(),
-            Uri::new("http://dbpedia.org/resource/".to_string()),
-        ));
-
         let foaf_maker = new_profile
             .graph
             .create_uri_node(&Uri::new("http://xmlns.com/foaf/0.1/maker".to_string()));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,6 +14,13 @@ fn profile_parses_without_error() {
 }
 
 #[test]
+fn no_unused_namespace_prefixes_in_output() {
+    let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
+    assert!(!ttl.contains("@prefix vcard:"), "vcard namespace must not appear (unused)");
+    assert!(!ttl.contains("@prefix resource:"), "resource namespace must not appear (unused)");
+}
+
+#[test]
 fn profile_name_in_output() {
     let ttl = convert_facebook_to_solid(PROFILE, None).unwrap();
     assert!(ttl.contains("Jane Doe-Smith"), "full name missing");


### PR DESCRIPTION
Closes #16

## Summary

Two `@prefix` declarations were written to every generated Turtle file despite no triple ever referencing either namespace:

- `@prefix vcard: <http://www.w3.org/2006/vcard/ns> .` — also missing the required `#` separator, so any future use would produce malformed compact IRIs
- `@prefix resource: <http://dbpedia.org/resource/> .`

Both removed from `Profile::new()`. A new regression test `no_unused_namespace_prefixes_in_output` asserts neither prefix appears in output.

## Test plan

- [x] `cargo test` — 26/26 tests pass (1 new), zero warnings
- [x] New test `no_unused_namespace_prefixes_in_output` asserts `@prefix vcard:` and `@prefix resource:` are absent
- [x] Confirmed remaining prefixes (`:`, `profile:`, `schema:`, `foaf:`) all still appear and all triples serialise correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)