### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary
Bumps all GitHub Actions workflow steps to their current latest major versions.
Each target version was verified against the action repo releases page.

## Changes
- `actions/checkout` @v4 -> @v6
- `actions/cache` @v4 -> @v5

## Verified latest versions
| Action | Latest |
|--------|--------|
| actions/checkout | v6.0.3 |
| actions/setup-node | v6.4.0 |
| actions/setup-java | v5.2.0 |
| actions/setup-python | v6.2.0 |
| actions/cache | v5.0.5 |
| actions/upload-artifact | v7.0.1 |
| actions/deploy-pages | v5.0.0 |
| actions/upload-pages-artifact | v5.0.0 |
| actions/configure-pages | v6.0.0 |
| pnpm/action-setup | v6.0.8 |
| gradle/actions/setup-gradle | v6.1.1 |
| alire-project/setup-alire | v6.0.0 |

## Merge criteria
Safe to merge if CI passes.
