### PR TITLE
fix: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What changed

Added `permissions: contents: read` to the `test` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).

## Why

CodeQL [code scanning alert #2](https://github.com/bushidocodes/hatchling/security/code-scanning/2) flagged the CI workflow for not defining explicit `GITHUB_TOKEN` permissions. Without an explicit block, the job inherits the repository-wide default (which may be read-write), violating the principle of least privilege.

The `test` job only checks out code and runs `cargo build`/`cargo test`, so `contents: read` is the minimum required permission.

## Reviewer notes

- No functional change — this is a security hygiene fix only.
- Once merged, the CodeQL alert will auto-close on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)