### PR TITLE
chore: add Dependabot cooldown (default-days: 3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
 ---


### PR DESCRIPTION
## Summary
Add a Dependabot `cooldown` of **3 days** under each `updates` entry so version bumps wait a few days after release before a PR is opened.

## Why
Avoids same-day bad/yanked releases. Matches the portfolio standard already applied on repos like `chord-grpc` and `keypunch`.

## Change
```yaml
cooldown:
  default-days: 3
```
